### PR TITLE
Use npm ci --ignore-scripts in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install dependencies and build Assets
         run: |
           composer install --no-dev --prefer-dist
-          npm install
+          npm ci --ignore-scripts
           npm run package
 
       - name: Generate readme.txt


### PR DESCRIPTION
## Summary
- Replace `npm install` with `npm ci --ignore-scripts` in deploy.yml
- Prevents execution of postinstall/lifecycle scripts during CI, mitigating supply chain attacks
- No functional impact: deploy workflow doesn't need husky hooks or other lifecycle scripts

## Test plan
- [ ] Deploy workflow still builds and deploys correctly on next release