### PR TITLE
Add a workflow to update WordPress.org assets without a release

### DIFF
--- a/.github/workflows/asset-update.yml
+++ b/.github/workflows/asset-update.yml
@@ -1,0 +1,35 @@
+name: Update WordPress.org assets
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - '.wordpress-org/**'
+      - 'README.md'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  assets:
+    name: Update assets on WordPress.org
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 7.4
+
+      - name: Generate readme.txt
+        uses: tarosky/workflows/actions/wp-readme@main
+
+      - name: Update assets and readme on WordPress.org
+        uses: 10up/action-wordpress-plugin-asset-update@stable
+        env:
+          SVN_USERNAME: ${{ secrets.WP_ORG_USERNAME_TAROSKY }}
+          SVN_PASSWORD: ${{ secrets.WP_ORG_PASSWORD_TAROSKY }}


### PR DESCRIPTION
## Background

Assets reach WordPress.org only through `deploy.yml`, which runs on `release: published`. Anything committed to `.wordpress-org/` therefore stays invisible until the next version ships.

Here, 1 file(s) in `.wordpress-org/` have never been published and 2 are live under the same name with different content.

Across the org this affects 12 of 15 plugins: 21 files never published, 12 live under the same name with different content. Most of it dates from a coordinated asset refresh on 2026-07-09/10 that no release has carried out yet.

## What this adds

A workflow that syncs `.wordpress-org/` and the generated `readme.txt` using `10up/action-wordpress-plugin-asset-update`, independent of releases. It uses the same secrets as `deploy.yml`.

- `push` to `master` touching `.wordpress-org/**` or `README.md` — keeps things current from now on
- `workflow_dispatch` — needed to publish what is already committed, since a path filter only reacts to future pushes

No plugin code is deployed by this workflow, so it does not release a version.

## Notes for review

- **`environment: production` is deliberately omitted.** `deploy.yml` declares it, and that environment carries a protection rule. Requiring an approval for every asset sync would defeat the purpose. This assumes `WP_ORG_USERNAME_TAROSKY` / `WP_ORG_PASSWORD_TAROSKY` are organization or repository secrets rather than environment-scoped ones — if the first run fails on empty credentials, that assumption was wrong and the line needs adding back.
- **`readme.txt` is synced too**, generated from `README.md` the same way `deploy.yml` does it. `Tested up to` is written as e.g. `7.0` rather than `7.0.2`; WordPress.org resolves that to the latest patch of the branch, so this does not lower any published value.
- Same change as tarosky/taro-cpt-front#55, which was reviewed first as a pilot.
