### PR TITLE
アセット更新ラッパーを追加（共有ワークフロー方式・#116 を置き換え）

### DIFF
--- a/.github/workflows/asset-update.yml
+++ b/.github/workflows/asset-update.yml
@@ -1,0 +1,11 @@
+name: Update WordPress.org assets
+
+on:
+  workflow_dispatch:
+
+jobs:
+  update:
+    uses: tarosky/workflows/.github/workflows/asset-update.yml@main
+    with:
+      slug: ${{ github.event.repository.name }}
+    secrets: inherit


### PR DESCRIPTION
## 概要

WordPress.org のアセット（アイコン・バナー・スクリーンショット）をリリースと独立して反映するための薄いラッパーを追加する。共有 reusable workflow (`tarosky/workflows/.github/workflows/asset-update.yml`) を `workflow_dispatch` で呼び出すだけ。

## 背景・方針

当初は各リポジトリに個別の `asset-update.yml` を追加する案（本リポジトリでは #116）だったが、以下の理由で共有ワークフロー方式に一本化した（tarosky/workflows#121, tarosky/workflows#122）。

- ロジックが14リポジトリに分散し、修正のたびに14PRが必要になる
- `10up/action-wordpress-plugin-asset-update` は readme.txt を trunk へ無条件同期するため、main に未リリースの README があると公開ページに漏洩するリスクがある

共有ワークフローは **自前の assets-only SVN commit** を採用しており、trunk / readme.txt には一切触れない。そのため `workflow_dispatch` をいつ実行しても未リリース README が漏れることはない。

この方針転換に伴い、旧 #116 はクローズする。

Refs tarosky/workflows#121
